### PR TITLE
Output versioned test vectors for conformance tests using the VC-API

### DIFF
--- a/conformancePreviousProof.js
+++ b/conformancePreviousProof.js
@@ -87,6 +87,11 @@ const findMatchingProofs = {
         matches.push(matchProof);
     }
     return matches;
+  },
+  missingPreviousProof(prevProofs, proofs){
+    // for this test prevProofs don't match proof ids
+    // so just return the proofs
+    return proofs;
   }
 }
 // create versioned VCs with previousProof as string
@@ -130,5 +135,16 @@ for(const [version, credential] of documents) {
   });
 }
 
-
-
+// create versioned VCs with previousProof as a Number
+for(const [version, credential] of documents) {
+  await secureDocument({
+    baseDir,
+    credential,
+    chainKeys,
+    fileName: `${version}-previousProofMissingFail`,
+    findMatchingProofs: findMatchingProofs.missingPreviousProof,
+    previousProofType: 'string',
+    previousProofs: [null, 'urn:uuid:38329423-2179-4b2e-88cb-a7c7d9dc4544'],
+    proofIds
+  });
+}

--- a/conformancePreviousProof.js
+++ b/conformancePreviousProof.js
@@ -135,7 +135,7 @@ for(const [version, credential] of documents) {
   });
 }
 
-// create versioned VCs with previousProof as a Number
+// create versioned VCs with missing previousProof
 for(const [version, credential] of documents) {
   await secureDocument({
     baseDir,
@@ -144,6 +144,7 @@ for(const [version, credential] of documents) {
     fileName: `${version}-previousProofMissingFail`,
     findMatchingProofs: findMatchingProofs.missingPreviousProof,
     previousProofType: 'string',
+    // this will result in a signed VC with a missing previousProof
     previousProofs: [null, 'urn:uuid:38329423-2179-4b2e-88cb-a7c7d9dc4544'],
     proofIds
   });

--- a/conformancePreviousProof.js
+++ b/conformancePreviousProof.js
@@ -35,6 +35,7 @@ for(const [version, credential] of documents) {
     credential,
     fileName: `${version}-previousProofStringOk`,
     previousProofType: 'string',
+    findMatchingProofs,
     chainKeys
   });
 }
@@ -44,6 +45,7 @@ for(const [version, credential] of documents) {
     baseDir,
     credential,
     fileName: `${version}-previousProofArrayOk`,
+    findMatchingProofs,
     previousProofType: 'Array',
     chainKeys
   });
@@ -56,7 +58,40 @@ for(const [version, credential] of documents) {
     credential,
     chainKeys,
     fileName: `${version}-previousProofNotStringFail`,
+    findMatchingProofs,
     previousProofType: 'string',
     proofIds: [456321]
   });
+}
+
+
+// function to get all matching proofs (only first level no dependencies)
+// prevProofs is either a string or an array
+// proofs is an array of proofs
+function findMatchingProofs(prevProofs, proofs) {
+  console.log(`findMatch called with ${prevProofs}`);
+  let matches = [];
+  if (!prevProofs) { // In case of no previous proof edge case
+    return matches;
+  }
+  if (Array.isArray(prevProofs)) {
+      prevProofs.forEach(pp => {
+        // NOTE String is strictly for allowing the creation
+        // of invalid test data in this case a number as a previousProof
+        let matchProof = proofs.find(p => p.id === String(pp));
+        if (!matchProof) {
+          throw new Error(`Missing proof for id = ${pp}`);
+        }
+        matches.push(matchProof);
+      })
+  } else {
+      // NOTE String is strictly for allowing the creation
+      // of invalid test data in this case a number as a previousProof
+      let matchProof = proofs.find(p => p.id === String(prevProofs));
+      if (!matchProof) {
+        throw new Error(`Missing proof for id = ${prevProofs}`);
+      }
+      matches.push(matchProof);
+  }
+  return matches;
 }

--- a/conformancePreviousProof.js
+++ b/conformancePreviousProof.js
@@ -1,0 +1,62 @@
+/*
+    Steps to create a signed verifiable credential with a simple
+    proof chain using Ed25519 signatures.
+*/
+
+import { mkdir } from 'fs/promises';
+import { createRequire } from 'module';
+import jsonld from 'jsonld';
+import { localLoader } from './documentLoader.js';
+import {secureDocument} from './conformanceTools.js';
+
+
+const require = createRequire(import.meta.url);
+
+// Create output directory for the results
+const baseDir = "./output/eddsa-rdfc-2022/conformance/";
+// recursively create the dirs for the baseDir is needed
+let status = await mkdir(baseDir, {recursive: true});
+
+jsonld.documentLoader = localLoader; // Local loader for JSON-LD
+
+const keyPairs = require('./input/multiKeyPairs.json');
+const chainKeys = [keyPairs.keyPair1, keyPairs.keyPair2]
+
+// Read input documents from files.
+const documents = new Map([
+  ['1.1', require('./input/v1/unsecured.json')],
+  ['2.0', require('./input/v2/unsecured.json')]
+]);
+
+// create versioned VCs with previousProof as string
+for(const [version, credential] of documents) {
+  await secureDocument({
+    baseDir,
+    credential,
+    fileName: `${version}-previousProofStringOk`,
+    previousProofType: 'string',
+    chainKeys
+  });
+}
+// create versioned VCs with previousProof as an Array
+for(const [version, credential] of documents) {
+  await secureDocument({
+    baseDir,
+    credential,
+    fileName: `${version}-previousProofArrayOk`,
+    previousProofType: 'Array',
+    chainKeys
+  });
+}
+
+// create versioned VCs with previousProof as a Number
+for(const [version, credential] of documents) {
+  await secureDocument({
+    baseDir,
+    credential,
+    chainKeys,
+    fileName: `${version}-previousProofNotStringFail`,
+    previousProofType: 'string',
+    proofIds: [456321]
+  });
+}

--- a/conformancePreviousProof.js
+++ b/conformancePreviousProof.js
@@ -22,6 +22,12 @@ jsonld.documentLoader = localLoader; // Local loader for JSON-LD
 const keyPairs = require('./input/multiKeyPairs.json');
 const chainKeys = [keyPairs.keyPair1, keyPairs.keyPair2]
 
+const previousProof = 'urn:uuid:26329423-bec9-4b2e-88cb-a7c7d9dc4544';
+const proofIds = [previousProof];
+// set the first entry to null to prevent the first proof
+// from having a previousProof set
+const previousProofs = [null, previousProof];
+
 // Read input documents from files.
 const documents = new Map([
   ['1.1', require('./input/v1/unsecured.json')],
@@ -90,6 +96,8 @@ for(const [version, credential] of documents) {
     credential,
     fileName: `${version}-previousProofStringOk`,
     previousProofType: 'string',
+    proofIds,
+    previousProofs,
     findMatchingProofs: findMatchingProofs.valid,
     chainKeys
   });
@@ -102,6 +110,8 @@ for(const [version, credential] of documents) {
     fileName: `${version}-previousProofArrayOk`,
     findMatchingProofs: findMatchingProofs.valid,
     previousProofType: 'Array',
+    proofIds,
+    previousProofs,
     chainKeys
   });
 }
@@ -115,7 +125,8 @@ for(const [version, credential] of documents) {
     fileName: `${version}-previousProofNotStringFail`,
     findMatchingProofs: findMatchingProofs.invalidType,
     previousProofType: 'string',
-    proofIds: [456321]
+    previousProofs: [456321],
+    proofIds: ['456321']
   });
 }
 

--- a/conformancePreviousProof.js
+++ b/conformancePreviousProof.js
@@ -141,9 +141,23 @@ for(const [version, credential] of documents) {
     baseDir,
     credential,
     chainKeys,
-    fileName: `${version}-previousProofMissingFail`,
+    fileName: `${version}-previousProofStringMissingFail`,
     findMatchingProofs: findMatchingProofs.missingPreviousProof,
     previousProofType: 'string',
+    // this will result in a signed VC with a missing previousProof
+    previousProofs: [null, 'urn:uuid:38329423-2179-4b2e-88cb-a7c7d9dc4544'],
+    proofIds
+  });
+}
+// create versioned VCs with missing previousProof
+for(const [version, credential] of documents) {
+  await secureDocument({
+    baseDir,
+    credential,
+    chainKeys,
+    fileName: `${version}-previousProofArrayMissingFail`,
+    findMatchingProofs: findMatchingProofs.missingPreviousProof,
+    previousProofType: 'Array',
     // this will result in a signed VC with a missing previousProof
     previousProofs: [null, 'urn:uuid:38329423-2179-4b2e-88cb-a7c7d9dc4544'],
     proofIds

--- a/conformancePreviousProof.js
+++ b/conformancePreviousProof.js
@@ -71,7 +71,7 @@ const findMatchingProofs = {
         prevProofs.forEach(pp => {
           // NOTE String is strictly for allowing the creation
           // of invalid test data in this case a number as a previousProof
-          let matchProof = proofs.find(p => p.id === String(pp));
+          let matchProof = proofs.find(p => String(p.id) === String(pp));
           if (!matchProof) {
             throw new Error(`Missing proof for id = ${pp}`);
           }
@@ -80,7 +80,7 @@ const findMatchingProofs = {
     } else {
         // NOTE String is strictly for allowing the creation
         // of invalid test data in this case a number as a previousProof
-        let matchProof = proofs.find(p => p.id === String(prevProofs));
+        let matchProof = proofs.find(p => String(p.id) === String(prevProofs));
         if (!matchProof) {
           throw new Error(`Missing proof for id = ${prevProofs}`);
         }
@@ -125,7 +125,7 @@ for(const [version, credential] of documents) {
     fileName: `${version}-previousProofNotStringFail`,
     findMatchingProofs: findMatchingProofs.invalidType,
     previousProofType: 'string',
-    previousProofs: [456321],
+    previousProofs: [null, 456321],
     proofIds: ['456321']
   });
 }

--- a/conformancePreviousProofOk.js
+++ b/conformancePreviousProofOk.js
@@ -164,6 +164,7 @@ function findMatchingProofs(prevProofs, proofs) {
   return matches;
 }
 
+// take in a key document and returns a verificationMethod
 function getVM(key) {
   if(!key) {
     throw new Error(`Expected a key document got ${key}`)
@@ -172,6 +173,7 @@ function getVM(key) {
     '#' + key.publicKeyMultibase
 }
 
+// create versioned VCs with previousProof as string
 for(const [version, credential] of documents) {
   await secureDocument({
     credential,
@@ -179,6 +181,7 @@ for(const [version, credential] of documents) {
     previousProofType: 'string'
   });
 }
+// create versioned VCs with previousProof as an Array
 for(const [version, credential] of documents) {
   await secureDocument({
     credential,

--- a/conformancePreviousProofOk.js
+++ b/conformancePreviousProofOk.js
@@ -80,7 +80,7 @@ async function secureDocument({
     let proofConfigChain = {};
     proofConfigChain.type = "DataIntegrityProof";
     if (i !== (chainKeys.length - 1)) { // Don't need id for last item in chain
-      proofConfigChain.id = proofIds[i];
+      proofConfigChain.id = String(proofIds[i]);
     }
     proofConfigChain.cryptosuite = "eddsa-rdfc-2022";
     proofConfigChain.created = `2023-02-26T22:${i}6:38Z`; // Signing later for realism ;-)
@@ -155,7 +155,7 @@ function findMatchingProofs(prevProofs, proofs) {
         matches.push(matchProof);
       })
   } else {
-      let matchProof = proofs.find(p => p.id === prevProofs);
+      let matchProof = proofs.find(p => p.id === String(prevProofs));
       if (!matchProof) {
         throw new Error(`Missing proof for id = ${prevProofs}`);
       }
@@ -194,8 +194,8 @@ for(const [version, credential] of documents) {
 for(const [version, credential] of documents) {
   await secureDocument({
     credential,
-    fileName: `${version}-previousProofNotUrlFail`,
+    fileName: `${version}-previousProofNotStringFail`,
     previousProofType: 'string',
-    proofIds: ['notUrl']
+    proofIds: [456321]
   });
 }

--- a/conformancePreviousProofOk.js
+++ b/conformancePreviousProofOk.js
@@ -189,3 +189,13 @@ for(const [version, credential] of documents) {
     previousProofType: 'Array'
   });
 }
+
+// create versioned VCs with previousProof as an Array
+for(const [version, credential] of documents) {
+  await secureDocument({
+    credential,
+    fileName: `${version}-previousProofNotUrlFail`,
+    previousProofType: 'string',
+    proofIds: ['notUrl']
+  });
+}

--- a/conformancePreviousProofOk.js
+++ b/conformancePreviousProofOk.js
@@ -1,0 +1,149 @@
+/*
+    Steps to create a signed verifiable credential with a simple
+    proof chain using Ed25519 signatures.
+*/
+
+import { mkdir, readFile, writeFile } from 'fs/promises';
+import { createRequire } from 'module';
+import jsonld from 'jsonld';
+import { localLoader } from './documentLoader.js';
+import { base58btc } from "multiformats/bases/base58";
+import {ed25519 as ed} from '@noble/curves/ed25519';
+import { sha256 } from '@noble/hashes/sha256';
+import { bytesToHex, concatBytes } from '@noble/hashes/utils';
+
+
+const require = createRequire(import.meta.url);
+
+// Create output directory for the results
+const baseDir = "./output/eddsa-rdfc-2022/conformance";
+let status = await mkdir(baseDir, {recursive: true});
+
+jsonld.documentLoader = localLoader; // Local loader for JSON-LD
+
+const keyPairs = require('./input/multiKeyPairs.json');
+    
+
+// Read input documents from files.
+const documents = new Map([
+  ['1.1', require('./input/v1/unsecured.json')],
+  ['2.0', require('./input/v2/unsecured.json']
+]);
+
+// Signed Document Creation Steps:
+
+// Canonize the document
+let cannon = await jsonld.canonize(document);
+// console.log("Canonized unsigned document:")
+// console.log(cannon);
+// writeFile(baseDir + 'canonDocDataInt.txt', cannon);
+
+// Hash canonized document
+let docHash = sha256(cannon); // @noble/hash will convert string to bytes via UTF-8
+// console.log("Hash of canonized document in hex:")
+// console.log(bytesToHex(docHash));
+// writeFile(baseDir + 'docHashDataInt.txt', bytesToHex(docHash));
+
+const proofIds = ["urn:uuid:26329423-bec9-4b2e-88cb-a7c7d9dc4544"];
+
+// **Proof Chains** starting from document
+let signedDocument = Object.assign({}, document);
+const chainKeys = [keyPairs.keyPair1, keyPairs.keyPair2];
+const previousProofs = [null, proofIds[0]]; // Simple proof chain
+for (let i = 0; i < chainKeys.length; i++) {
+  let allProofs;
+  if (Array.isArray(signedDocument.proof)) {
+    allProofs = signedDocument.proof;
+  } else { 
+    if (signedDocument.proof === undefined) {
+      allProofs = [];
+    } else {
+      allProofs = [signedDocument.proof];
+    }
+    console.log(`signedDocument.proof = ${signedDocument.proof}`)
+  }
+  console.log(`allProofs = ${JSON.stringify(allProofs)}`)
+  // if (!allProofs) { // In case starting document doesn't have a proof
+  //   allProofs = [];
+  // }
+  // Set up the proof configuration for the chain
+  let proofConfigChain = {};
+  proofConfigChain.type = "DataIntegrityProof";
+  if (i !== (chainKeys.length - 1)) { // Don't need id for last item in chain
+    proofConfigChain.id = proofIds[i];
+  }
+  proofConfigChain.cryptosuite = "eddsa-rdfc-2022";
+  proofConfigChain.created = `2023-02-26T22:${i}6:38Z`; // Signing later for realism ;-)
+  proofConfigChain.verificationMethod = 'did:key:' + chainKeys[i].publicKeyMultibase + 
+    '#' + chainKeys[i].publicKeyMultibase;
+
+  proofConfigChain.proofPurpose = "assertionMethod";
+  if (previousProofs[i]) { // If no previous proof don't set the option.
+    proofConfigChain.previousProof = previousProofs[i];
+  }
+  writeFile(baseDir + `proofChainSimpleConfig${i+1}.json`, JSON.stringify(proofConfigChain, null, 2));
+  proofConfigChain["@context"] = document["@context"];
+  // Dave's algorithm update
+  let matchingProofs = findMatchingProofs(previousProofs[i], allProofs);
+  document.proof = matchingProofs;
+  console.log(`Matching proofs for i = ${i}`);
+  console.log(matchingProofs);
+  // Canonize the "chained" document
+  writeFile(baseDir + `proofChainSimpleTempDoc${i+1}.json`, JSON.stringify(document, null, 2));
+  cannon = await jsonld.canonize(document);
+
+  // Hash canonized chained document
+  docHash = sha256(cannon); // @noble/hash will convert string to bytes via UTF-8
+
+  // canonize the proof config
+  let proofCanon = await jsonld.canonize(proofConfigChain);
+
+  // Hash canonized proof config
+  let proofHash = sha256(proofCanon); // @noble/hash will convert string to bytes via UTF-8
+
+  // Combine hashes
+  let combinedHash = concatBytes(proofHash, docHash);
+
+  // Sign
+  let privKey = base58btc.decode(chainKeys[i].privateKeyMultibase);
+  privKey = privKey.slice(2, 34); // only want the first 2-34 bytes
+  // console.log(`Secret key length ${privKey.length}, value in hex:`);
+  let signature = await ed.sign(combinedHash, privKey);
+  proofConfigChain.proofValue = base58btc.encode(signature);
+  delete proofConfigChain['@context'];
+  writeFile(baseDir + `proofChainSimpleConfigSigned${i+1}.json`, JSON.stringify(proofConfigChain, null, 2));
+
+// Construct Signed Document
+  signedDocument = Object.assign({}, document);
+  signedDocument.proof = allProofs.concat(proofConfigChain);
+
+// console.log(JSON.stringify(signedDocument, null, 2));
+  writeFile(baseDir + `signedProofChainSimple${i+1}.json`, JSON.stringify(signedDocument, null, 2));
+}
+
+// function to get all matching proofs (only first level no dependencies)
+// prevProofs is either a string or an array
+// proofs is an array of proofs
+function findMatchingProofs(prevProofs, proofs) {
+  console.log(`findMatch called with ${prevProofs}`);
+  let matches = [];
+  if (!prevProofs) { // In case of no previous proof edge case
+    return matches;
+  }
+  if (Array.isArray(prevProofs)) {
+      prevProofs.forEach(pp => {
+        let matchProof = proofs.find(p => p.id === pp);
+        if (!matchProof) {
+          throw new Error(`Missing proof for id = ${pp}`);
+        }
+        matches.push(matchProof);
+      })
+  } else {
+      let matchProof = proofs.find(p => p.id === prevProofs);
+      if (!matchProof) {
+        throw new Error(`Missing proof for id = ${prevProofs}`);
+      }
+      matches.push(matchProof);
+  }
+  return matches;
+}

--- a/conformancePreviousProofOk.js
+++ b/conformancePreviousProofOk.js
@@ -32,7 +32,7 @@ const documents = new Map([
 ]);
 
 
-async function secureDocument(document) {
+async function secureDocument({version, document}) {
   // Signed Document Creation Steps:
   
   // Canonize the document
@@ -83,7 +83,7 @@ async function secureDocument(document) {
     if (previousProofs[i]) { // If no previous proof don't set the option.
       proofConfigChain.previousProof = previousProofs[i];
     }
-    writeFile(baseDir + `proofChainSimpleConfig${i+1}.json`, JSON.stringify(proofConfigChain, null, 2));
+    writeFile(baseDir + `${version}-proofChainSimpleConfig${i+1}.json`, JSON.stringify(proofConfigChain, null, 2));
     // temporarily add doc's context to proof options for canonization
     proofConfigChain["@context"] = document["@context"];
     // Dave's algorithm update
@@ -92,7 +92,7 @@ async function secureDocument(document) {
     console.log(`Matching proofs for i = ${i}`);
     console.log(matchingProofs);
     // Canonize the "chained" document
-    writeFile(baseDir + `proofChainSimpleTempDoc${i+1}.json`, JSON.stringify(document, null, 2));
+    writeFile(baseDir + `${version}-proofChainSimpleTempDoc${i+1}.json`, JSON.stringify(document, null, 2));
     cannon = await jsonld.canonize(document);
   
     // Hash canonized chained document
@@ -114,14 +114,14 @@ async function secureDocument(document) {
     let signature = await ed.sign(combinedHash, privKey);
     proofConfigChain.proofValue = base58btc.encode(signature);
     delete proofConfigChain['@context'];
-    writeFile(baseDir + `proofChainSimpleConfigSigned${i+1}.json`, JSON.stringify(proofConfigChain, null, 2));
+    writeFile(baseDir + `${version}-proofChainSimpleConfigSigned${i+1}.json`, JSON.stringify(proofConfigChain, null, 2));
   
   // Construct Signed Document
     signedDocument = structuredClone(document);
     signedDocument.proof = allProofs.concat(proofConfigChain);
   
   // console.log(JSON.stringify(signedDocument, null, 2));
-    writeFile(baseDir + `signedProofChainSimple${i+1}.json`, JSON.stringify(signedDocument, null, 2));
+    writeFile(baseDir + `${version}-signedProofChainSimple${i+1}.json`, JSON.stringify(signedDocument, null, 2));
   }
 }
 
@@ -160,6 +160,6 @@ function getVM(key) {
     '#' + key.publicKeyMultibase
 }
 
-for(const [version, doc] of documents) {
-  await secureDocument(doc);
+for(const [version, document] of documents) {
+  await secureDocument({version, document});
 }

--- a/conformanceTools.js
+++ b/conformanceTools.js
@@ -1,9 +1,4 @@
-/*
-    Steps to create a signed verifiable credential with a simple
-    proof chain using Ed25519 signatures.
-*/
-
-import { mkdir, writeFile } from 'fs/promises';
+import { writeFile } from 'fs/promises';
 import { createRequire } from 'module';
 import jsonld from 'jsonld';
 import { localLoader } from './documentLoader.js';
@@ -12,51 +7,35 @@ import {ed25519 as ed} from '@noble/curves/ed25519';
 import { sha256 } from '@noble/hashes/sha256';
 import { bytesToHex, concatBytes } from '@noble/hashes/utils';
 
-
-const require = createRequire(import.meta.url);
-
-// Create output directory for the results
-const baseDir = "./output/eddsa-rdfc-2022/conformance/";
-// recursively create the dirs for the baseDir is needed
-let status = await mkdir(baseDir, {recursive: true});
-
-jsonld.documentLoader = localLoader; // Local loader for JSON-LD
-
-const keyPairs = require('./input/multiKeyPairs.json');
-    
-
-// Read input documents from files.
-const documents = new Map([
-  ['1.1', require('./input/v1/unsecured.json')],
-  ['2.0', require('./input/v2/unsecured.json')]
-]);
-
-
-async function secureDocument({
+export async function secureDocument({
+  baseDir,
+  chainKeys,
   credential,
   proofIds = ["urn:uuid:26329423-bec9-4b2e-88cb-a7c7d9dc4544"],
   fileName,
-  previousProofType
+  previousProofType,
+  debug = false
 }) {
   const document = structuredClone(credential);
-  // Signed Document Creation Steps:
-  
-  // Canonize the document
-  let cannon = await jsonld.canonize(document);
-  // console.log("Canonized unsigned document:")
-  // console.log(cannon);
-  // writeFile(baseDir + 'canonDocDataInt.txt', cannon);
-  
-  // Hash canonized document
-  let docHash = sha256(cannon); // @noble/hash will convert string to bytes via UTF-8
-  // console.log("Hash of canonized document in hex:")
-  // console.log(bytesToHex(docHash));
-  // writeFile(baseDir + 'docHashDataInt.txt', bytesToHex(docHash));
+  if(debug) {
+    // Signed Document Creation Steps:
+    
+    // Canonize the document
+    let cannon = await jsonld.canonize(document);
+    console.log("Canonized unsigned document:")
+    console.log(cannon);
+    writeFile(baseDir + 'canonDocDataInt.txt', cannon);
+    
+    // Hash canonized document
+    let docHash = sha256(cannon); // @noble/hash will convert string to bytes via UTF-8
+    console.log("Hash of canonized document in hex:")
+    console.log(bytesToHex(docHash));
+    writeFile(baseDir + 'docHashDataInt.txt', bytesToHex(docHash));
+  }
   
   
   // **Proof Chains** starting from document
   let signedDocument = structuredClone(document);
-  const chainKeys = [keyPairs.keyPair1, keyPairs.keyPair2];
   // set the first entry to null to prevent the first proof
   // from having a previousProof set
   const previousProofs = [null, proofIds[0]]; // Simple proof chain
@@ -105,10 +84,10 @@ async function secureDocument({
     console.log(matchingProofs);
     // Canonize the "chained" document
     writeFile(baseDir + `${fileName}-SimpleTempDoc${i+1}.json`, JSON.stringify(document, null, 2));
-    cannon = await jsonld.canonize(document);
+    const cannon = await jsonld.canonize(document);
   
     // Hash canonized chained document
-    docHash = sha256(cannon); // @noble/hash will convert string to bytes via UTF-8
+    const docHash = sha256(cannon); // @noble/hash will convert string to bytes via UTF-8
   
     // canonize the proof config
     let proofCanon = await jsonld.canonize(proofConfigChain);
@@ -173,29 +152,3 @@ function getVM(key) {
     '#' + key.publicKeyMultibase
 }
 
-// create versioned VCs with previousProof as string
-for(const [version, credential] of documents) {
-  await secureDocument({
-    credential,
-    fileName: `${version}-previousProofString`,
-    previousProofType: 'string'
-  });
-}
-// create versioned VCs with previousProof as an Array
-for(const [version, credential] of documents) {
-  await secureDocument({
-    credential,
-    fileName: `${version}-previousProofArray`,
-    previousProofType: 'Array'
-  });
-}
-
-// create versioned VCs with previousProof as an Array
-for(const [version, credential] of documents) {
-  await secureDocument({
-    credential,
-    fileName: `${version}-previousProofNotStringFail`,
-    previousProofType: 'string',
-    proofIds: [456321]
-  });
-}

--- a/conformanceTools.js
+++ b/conformanceTools.js
@@ -111,7 +111,7 @@ export async function secureDocument({
     signedDocument.proof = allProofs.concat(proofConfigChain);
 
   // console.log(JSON.stringify(signedDocument, null, 2));
-    writeFile(baseDir + `${fileName}-SimpleSinged${i+1}.json`, JSON.stringify(signedDocument, null, 2));
+    writeFile(baseDir + `${fileName}-SimpleSigned${i+1}.json`, JSON.stringify(signedDocument, null, 2));
   }
 }
 

--- a/conformanceTools.js
+++ b/conformanceTools.js
@@ -14,6 +14,7 @@ export async function secureDocument({
   proofIds = ["urn:uuid:26329423-bec9-4b2e-88cb-a7c7d9dc4544"],
   fileName,
   previousProofType,
+  findMatchingProofs,
   debug = false
 }) {
   const document = structuredClone(credential);
@@ -116,36 +117,6 @@ export async function secureDocument({
   }
 }
 
-// function to get all matching proofs (only first level no dependencies)
-// prevProofs is either a string or an array
-// proofs is an array of proofs
-function findMatchingProofs(prevProofs, proofs) {
-  console.log(`findMatch called with ${prevProofs}`);
-  let matches = [];
-  if (!prevProofs) { // In case of no previous proof edge case
-    return matches;
-  }
-  if (Array.isArray(prevProofs)) {
-      prevProofs.forEach(pp => {
-        // NOTE String is strictly for allowing the creation
-        // of invalid test data in this case a number as a previousProof
-        let matchProof = proofs.find(p => p.id === String(pp));
-        if (!matchProof) {
-          throw new Error(`Missing proof for id = ${pp}`);
-        }
-        matches.push(matchProof);
-      })
-  } else {
-      // NOTE String is strictly for allowing the creation
-      // of invalid test data in this case a number as a previousProof
-      let matchProof = proofs.find(p => p.id === String(prevProofs));
-      if (!matchProof) {
-        throw new Error(`Missing proof for id = ${prevProofs}`);
-      }
-      matches.push(matchProof);
-  }
-  return matches;
-}
 
 // take in a key document and returns a verificationMethod
 function getVM(key) {

--- a/conformanceTools.js
+++ b/conformanceTools.js
@@ -127,13 +127,17 @@ function findMatchingProofs(prevProofs, proofs) {
   }
   if (Array.isArray(prevProofs)) {
       prevProofs.forEach(pp => {
-        let matchProof = proofs.find(p => p.id === pp);
+        // NOTE String is strictly for allowing the creation
+        // of invalid test data in this case a number as a previousProof
+        let matchProof = proofs.find(p => p.id === String(pp));
         if (!matchProof) {
           throw new Error(`Missing proof for id = ${pp}`);
         }
         matches.push(matchProof);
       })
   } else {
+      // NOTE String is strictly for allowing the creation
+      // of invalid test data in this case a number as a previousProof
       let matchProof = proofs.find(p => p.id === String(prevProofs));
       if (!matchProof) {
         throw new Error(`Missing proof for id = ${prevProofs}`);

--- a/conformanceTools.js
+++ b/conformanceTools.js
@@ -58,7 +58,7 @@ export async function secureDocument({
     let proofConfigChain = {};
     proofConfigChain.type = "DataIntegrityProof";
     if (i !== (chainKeys.length - 1)) { // Don't need id for last item in chain
-      proofConfigChain.id = String(proofIds[i]);
+      proofConfigChain.id = proofIds[i];
     }
     proofConfigChain.cryptosuite = "eddsa-rdfc-2022";
     proofConfigChain.created = `2023-02-26T22:${i}6:38Z`; // Signing later for realism ;-)
@@ -124,4 +124,3 @@ function getVM(key) {
   return 'did:key:' + key.publicKeyMultibase +
     '#' + key.publicKeyMultibase
 }
-

--- a/contexts/data-integrity-v2.js
+++ b/contexts/data-integrity-v2.js
@@ -1,0 +1,81 @@
+export const diV2 = {
+  "@context": {
+    "id": "@id",
+    "type": "@type",
+    "@protected": true,
+    "proof": {
+      "@id": "https://w3id.org/security#proof",
+      "@type": "@id",
+      "@container": "@graph"
+    },
+    "DataIntegrityProof": {
+      "@id": "https://w3id.org/security#DataIntegrityProof",
+      "@context": {
+        "@protected": true,
+        "id": "@id",
+        "type": "@type",
+        "challenge": "https://w3id.org/security#challenge",
+        "created": {
+          "@id": "http://purl.org/dc/terms/created",
+          "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+        },
+        "domain": "https://w3id.org/security#domain",
+        "expires": {
+          "@id": "https://w3id.org/security#expiration",
+          "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+        },
+        "nonce": "https://w3id.org/security#nonce",
+        "previousProof": {
+          "@id": "https://w3id.org/security#previousProof",
+          "@type": "@id"
+        },
+        "proofPurpose": {
+          "@id": "https://w3id.org/security#proofPurpose",
+          "@type": "@vocab",
+          "@context": {
+            "@protected": true,
+            "id": "@id",
+            "type": "@type",
+            "assertionMethod": {
+              "@id": "https://w3id.org/security#assertionMethod",
+              "@type": "@id",
+              "@container": "@set"
+            },
+            "authentication": {
+              "@id": "https://w3id.org/security#authenticationMethod",
+              "@type": "@id",
+              "@container": "@set"
+            },
+            "capabilityInvocation": {
+              "@id": "https://w3id.org/security#capabilityInvocationMethod",
+              "@type": "@id",
+              "@container": "@set"
+            },
+            "capabilityDelegation": {
+              "@id": "https://w3id.org/security#capabilityDelegationMethod",
+              "@type": "@id",
+              "@container": "@set"
+            },
+            "keyAgreement": {
+              "@id": "https://w3id.org/security#keyAgreementMethod",
+              "@type": "@id",
+              "@container": "@set"
+            }
+          }
+        },
+        "cryptosuite": {
+          "@id": "https://w3id.org/security#cryptosuite",
+          "@type": "https://w3id.org/security#cryptosuiteString"
+        },
+        "proofValue": {
+          "@id": "https://w3id.org/security#proofValue",
+          "@type": "https://w3id.org/security#multibase"
+        },
+        "verificationMethod": {
+          "@id": "https://w3id.org/security#verificationMethod",
+          "@type": "@id"
+        }
+      }
+    }
+  }
+}

--- a/documentLoader.js
+++ b/documentLoader.js
@@ -4,6 +4,7 @@ import { vcv2 } from './contexts/credv2.js';
 import { examplesv2 } from './contexts/examples-v2.js';
 import { vcv1 } from './contexts/credv1.js';
 import { edv1 } from './contexts/ed25519-signature-2020-v1.js';
+import { diV2 } from './contexts/data-integrity-v2.js';
 
 
 // Set up a document loader so we don't have to go to the net
@@ -12,7 +13,8 @@ const CONTEXTS = {
     "https://www.w3.org/ns/credentials/examples/v2": { "@context": examplesv2 },
     "https://www.w3.org/2018/credentials/v1": { "@context": vcv1 },
     "https://w3id.org/citizenship/v1": { "@context": citizenv1 },
-    "https://w3id.org/security/suites/ed25519-2020/v1": { "@context": edv1 }
+    "https://w3id.org/security/suites/ed25519-2020/v1": { "@context": edv1 },
+    "https://w3id.org/security/data-integrity/v2": {"@context": diV2 }
 };
 // Only needed if you want remote loading, see comments below
 const nodeDocumentLoader = jsonld.documentLoaders.node();

--- a/input/v1/unsecured.json
+++ b/input/v1/unsecured.json
@@ -1,0 +1,20 @@
+{
+    "@context": [
+        "https://www.w3.org/2018/credentials/v1",
+      {"@context": {
+        "alumniOf": "https://www.example.org/alumniOf",
+        "description": "https://www.example.com/description",
+        "name": "https://www.example.com/name"
+      }}
+    ],
+    "id": "urn:uuid:58172aac-d8ba-11ed-83dd-0b3aef56cc33",
+    "type": ["VerifiableCredential", "AlumniCredential"],
+    "name": "Alumni Credential",
+    "description": "A minimum viable example of a VC 1.1 Alumni Credential.",
+    "issuer": "https://vc.example/issuers/5678",
+    "issuanceDate": "2023-01-01T00:00:00Z",
+    "credentialSubject": {
+        "id": "did:example:abcdefgh",
+        "alumniOf": "The School of Examples"
+    }
+}

--- a/input/v1/unsecured.json
+++ b/input/v1/unsecured.json
@@ -5,8 +5,8 @@
       {"@context": {
         "AlumniCredential": "https://www.example.org/AlumniCredential",
         "alumniOf": "https://www.example.org/alumniOf",
-        "description": "https://www.example.com/description",
-        "name": "https://www.example.com/name"
+        "description": "https://schema.org/description",
+        "name": "https://schema.org/name"
       }}
     ],
     "id": "urn:uuid:58172aac-d8ba-11ed-83dd-0b3aef56cc33",

--- a/input/v1/unsecured.json
+++ b/input/v1/unsecured.json
@@ -1,6 +1,7 @@
 {
     "@context": [
         "https://www.w3.org/2018/credentials/v1",
+        "https://w3id.org/security/data-integrity/v2",
       {"@context": {
         "AlumniCredential": "https://www.example.org/AlumniCredential",
         "alumniOf": "https://www.example.org/alumniOf",

--- a/input/v1/unsecured.json
+++ b/input/v1/unsecured.json
@@ -13,7 +13,7 @@
     "type": ["VerifiableCredential", "AlumniCredential"],
     "name": "Alumni Credential",
     "description": "A minimum viable example of a VC 1.1 Alumni Credential.",
-    "issuer": "https://vc.example/issuers/5678",
+    "issuer": "did:key:z6MkhWqdDBPojHA7cprTGTt5yHv5yUi1B8cnXn8ReLumkw6E",
     "issuanceDate": "2023-01-01T00:00:00Z",
     "credentialSubject": {
         "id": "did:example:abcdefgh",

--- a/input/v1/unsecured.json
+++ b/input/v1/unsecured.json
@@ -2,6 +2,7 @@
     "@context": [
         "https://www.w3.org/2018/credentials/v1",
       {"@context": {
+        "AlumniCredential": "https://www.example.org/AlumniCredential",
         "alumniOf": "https://www.example.org/alumniOf",
         "description": "https://www.example.com/description",
         "name": "https://www.example.com/name"

--- a/input/v2/unsecured.json
+++ b/input/v2/unsecured.json
@@ -6,7 +6,7 @@
     "id": "urn:uuid:58172aac-d8ba-11ed-83dd-0b3aef56cc33",
     "type": ["VerifiableCredential", "AlumniCredential"],
     "name": "Alumni Credential",
-    "description": "A minimum viable example of an Alumni Credential.",
+    "description": "A minimum viable example of a VC 2.0 Alumni Credential.",
     "issuer": "https://vc.example/issuers/5678",
     "validFrom": "2023-01-01T00:00:00Z",
     "credentialSubject": {

--- a/input/v2/unsecured.json
+++ b/input/v2/unsecured.json
@@ -11,7 +11,7 @@
     "type": ["VerifiableCredential", "AlumniCredential"],
     "name": "Alumni Credential",
     "description": "A minimum viable example of a VC 2.0 Alumni Credential.",
-    "issuer": "https://vc.example/issuers/5678",
+    "issuer": "did:key:z6MkhWqdDBPojHA7cprTGTt5yHv5yUi1B8cnXn8ReLumkw6E",
     "validFrom": "2023-01-01T00:00:00Z",
     "credentialSubject": {
         "id": "did:example:abcdefgh",

--- a/input/v2/unsecured.json
+++ b/input/v2/unsecured.json
@@ -1,0 +1,16 @@
+{
+    "@context": [
+        "https://www.w3.org/ns/credentials/v2",
+      {"@context": {"alumniOf": "https://www.example.org/alumniOf"}}
+    ],
+    "id": "urn:uuid:58172aac-d8ba-11ed-83dd-0b3aef56cc33",
+    "type": ["VerifiableCredential", "AlumniCredential"],
+    "name": "Alumni Credential",
+    "description": "A minimum viable example of an Alumni Credential.",
+    "issuer": "https://vc.example/issuers/5678",
+    "validFrom": "2023-01-01T00:00:00Z",
+    "credentialSubject": {
+        "id": "did:example:abcdefgh",
+        "alumniOf": "The School of Examples"
+    }
+}

--- a/input/v2/unsecured.json
+++ b/input/v2/unsecured.json
@@ -1,7 +1,11 @@
 {
     "@context": [
         "https://www.w3.org/ns/credentials/v2",
-      {"@context": {"alumniOf": "https://www.example.org/alumniOf"}}
+      {"@context": {
+        "AlumniCredential": "https://www.example.org/AlumniCredential",
+        "alumniOf": "https://www.example.org/alumniOf"
+        }
+      }
     ],
     "id": "urn:uuid:58172aac-d8ba-11ed-83dd-0b3aef56cc33",
     "type": ["VerifiableCredential", "AlumniCredential"],


### PR DESCRIPTION
@Wind4Greg so this contains 2 new scripts that produce the test vectors for the normative statements in the test suite for proofChains. If you want it it's yours if not I can just export the scripts to the data integrity suite. Both versions of the positive tests pass verification.

To Do
- [x] ensure previousProofStringOk verifies
- [x] ensure previousProofArrayOk verifies
- [x] Change example to schema.org urls if possible